### PR TITLE
Fix compilation issues on (some?) *nix systems

### DIFF
--- a/include/ztd/text/detail/posix.hpp
+++ b/include/ztd/text/detail/posix.hpp
@@ -40,7 +40,18 @@
 #if ZTD_TEXT_IS_ON(ZTD_TEXT_PLATFORM_UNIX_I_)
 
 extern "C" {
+#if !defined(__has_include)
+// We can't detect it automatically. Most commonly, header is in langinfo.h
+#include <langinfo.h>
+#elif ZTD_TEXT_HAS_INCLUDE_I_(<nl_langinfo.h>)
+// Some platforms have an nl_langinfo.h instead
 #include <nl_langinfo.h>
+#elif ZTD_TEXT_HAS_INCLUDE_I_(<langinfo.h>)
+// <langinfo.h> is the standard name per POSIX
+#include <langinfo.h>
+#else
+#error "No langinfo.h header is available"
+#endif
 }
 
 namespace ztd { namespace text {


### PR DESCRIPTION
Congratulations on publication!

I pulled the repo and found some issues that prevented compilation. They seem simple enough:

- Fix a (usually) incorrect header name on POSIX. The standard header name is `<langinfo.h>`, but the `#include` directive refers to `<nl_langinfo.h>`, which only seems to exist on some strange IBM systems (as always).
- Some incorrectly unqualified identifiers. Some code declared members without an `__` prefix, but then expected them to be `__` prefixed, and sometimes the other way around.
- Some transposed member names in wide char encoding on *nix. A few times, encoding state between wide/narrow objects were passed for `mbstate` pointers, and it looks like they should have been swapped.