### PR TITLE
fix various typos

### DIFF
--- a/documentation/source/definitions.rst
+++ b/documentation/source/definitions.rst
@@ -31,7 +31,7 @@
 Glossary of Terms & Definitions
 ===============================
 
-Occassionally, we may need to use precise language to describe what we want. This contains a list of definitions that can be linked to from the documentation to help describe key concepts that are useful for the explication of the concepts and ideas found in this documentation.
+Occasionally, we may need to use precise language to describe what we want. This contains a list of definitions that can be linked to from the documentation to help describe key concepts that are useful for the explication of the concepts and ideas found in this documentation.
 
 
 .. glossary::
@@ -55,7 +55,7 @@ Occassionally, we may need to use precise language to describe what we want. Thi
 
 		A unicode code point has been reserved to take at most 21 bits of space to identify itself.
 
-		A single unicode code point is NOT equivalent to a :term:`character <character>`, and multiple of them can be put together or taken apart and still have their sequence form a :term:`"character" <character>`. For a more holsitic, human-like interpretation of code points or other data, see :term:`grapheme clusters <grapheme cluster>`.
+		A single unicode code point is NOT equivalent to a :term:`character <character>`, and multiple of them can be put together or taken apart and still have their sequence form a :term:`"character" <character>`. For a more holistic, human-like interpretation of code points or other data, see :term:`grapheme clusters <grapheme cluster>`.
 
 	unicode scalar value
 		A single unit of decoded information for Unicode. It's definition is identical to that of :term:`unicode code points <unicode code point>`, with the additional constraint that every unicode svalar value may not be a "Surrogate Value". Surrogate values are non-characters used exclusively for the purpose of encoding and decoding specific sequences of code units, and therefore carry no useful meaning in general interchange. They may appear in text streams in certain encodings: see :doc:`Wobbly Transformation Format-8 (WTF-8) </api/encodings/wtf8>` for an example.

--- a/documentation/source/design/strong vs weak code points.rst
+++ b/documentation/source/design/strong vs weak code points.rst
@@ -75,11 +75,11 @@ In a long piece on P0422, the C and C++ landscape, and Standardization efforts, 
 
 	-- `Henri Sivonen, It’s Time to Stop Adding New Features for Non-Unicode Execution Encodings in C++ <https://hsivonen.fi/non-unicode-in-cpp/>`_
 
-This is a different set of choices and a different set of priorities from the outset. Sivonen's work specifically is that with Browsers and large code bases like Firefox; they are responsible for making very good traction and progress on encoding issues in a world that is filled primarily with Unicode, but still has millions of documents that are not in Unicode and, for the forseeable future, won't end up as Unicode.
+This is a different set of choices and a different set of priorities from the outset. Sivonen's work specifically is that with Browsers and large code bases like Firefox; they are responsible for making very good traction and progress on encoding issues in a world that is filled primarily with Unicode, but still has millions of documents that are not in Unicode and, for the foreseeable future, won't end up as Unicode.
 
 This is a strong argument for simply channeling ``char16_t``, ``char32_t``, and -- since C++20 -- ``char8_t`` as the only types one would need. Firefox at most deals in UTF-16 (due to the JavaScript engine for legacy reasons) and UTF-8, internally. At the boundaries, it deals with many more text encodings, because it `has to from the world wide web <https://encoding.spec.whatwg.org/>`_. Occasionally, UTF-32 will appear in someone's codebase for interoperation purposes or algorithms that need to operate on something better than code units. 
 
-Unicode is also... well, a [UNI]versal [CODE]. It's purposes is interoperation, interchange, and common ground between all the encodings, and it has been the clear winner for this for quite some time now. Sivonen makes a compelling point for just considering Unicode — and only Unicode — for all future text endeavors.
+Unicode is also... well, a [UNI]versal [CODE]. Its purposes are interoperation, interchange, and common ground between all the encodings, and it has been the clear winner for this for quite some time now. Sivonen makes a compelling point for just considering Unicode — and only Unicode — for all future text endeavors.
 
 Do we really need to focus on having support for legacy encodings? Or at least, do we really need support for legacy encodings at the level that Tom Honermann's text_view is trying to achieve?
 
@@ -112,7 +112,7 @@ There is room in Sivonen's world, even with perfectly-consistent and fully-Unico
 
 That's why encodings can still define their own ``code_unit`` and ``code_point`` types; even if this library — or the Standard Library — traffics in strictly ``unicode_code_point``\ s, it doesn't mean the user should be forced to do that if they are willing to put in the effort for a more type-safe world.
 
-Being able to know, at compile-time, without any objects or markup, that a particular pointer + size pairing is meant for a specific encoding is aa powerful way to maintain invariants and track the flow of data without runtime cost through a program. It can also make it easy to find places where external, non-Unicode data is making it "too far" into the system, and try to push a conversion closer to the edges of the program.
+Being able to know, at compile-time, without any objects or markup, that a particular pointer + size pairing is meant for a specific encoding is a powerful way to maintain invariants and track the flow of data without runtime cost through a program. It can also make it easy to find places where external, non-Unicode data is making it "too far" into the system, and try to push a conversion closer to the edges of the program.
 
 While ztd.text will traffic and work with ``char32_t`` and consider it a ``unicode_code_point`` value :doc:`under most circumstances </api/is_unicode_code_point>`, users are free to define and extend this classification for their own types and generally create as strict (or loose) as taxonomy as they desire.
 

--- a/examples/documentation/source/error_handler.anatomy.cpp
+++ b/examples/documentation/source/error_handler.anatomy.cpp
@@ -31,7 +31,7 @@
 #include <ztd/text.hpp>
 
 struct my_error_handler {
-	// Helper definintions
+	// Helper definitions
 	template <typename Encoding>
 	using code_point_span
 	     = ztd::text::span<const ztd::text::code_point_t<Encoding>>;
@@ -39,7 +39,7 @@ struct my_error_handler {
 	using code_unit_span
 	     = ztd::text::span<const ztd::text::code_unit_t<Encoding>>;
 
-	// Function call operatorthat returns a "deduced" (auto) type
+	// Function call operator that returns a "deduced" (auto) type
 	// Specifically, this one is called for encode failures
 	template <typename Encoding, typename Input, typename Output,
 	     typename State>


### PR DESCRIPTION
Just a couple typos I found while reading through some of the documentation, assuming "Gooogle" wasn't a play on how massive the company is. :)