### PR TITLE
Fix: `throw_handler` should return non-void

### DIFF
--- a/include/ztd/text/error_handler.hpp
+++ b/include/ztd/text/error_handler.hpp
@@ -306,7 +306,7 @@ namespace ztd { namespace text {
 		template <typename _Encoding, typename _InputRange, typename _OutputRange, typename _State,
 			typename _Progress>
 		constexpr auto operator()(const _Encoding&, encode_result<_InputRange, _OutputRange, _State> __result,
-			const _Progress&) const noexcept(false) {
+			const _Progress&) const noexcept(false) -> encode_result<_InputRange, _OutputRange, _State> {
 			throw __result.error_code;
 		}
 
@@ -317,7 +317,7 @@ namespace ztd { namespace text {
 		template <typename _Encoding, typename _InputRange, typename _OutputRange, typename _State,
 			typename _Progress>
 		constexpr auto operator()(const _Encoding&, decode_result<_InputRange, _OutputRange, _State> __result,
-			const _Progress&) const noexcept(false) {
+			const _Progress&) const noexcept(false) -> decode_result<_InputRange, _OutputRange, _State> {
 			throw __result.error_code;
 		}
 	};


### PR DESCRIPTION
The following code fails to compile:

```c++
string in;
u8string out;
utf8::state state;
utf8::encode_one(in, out, throw_handler{}, state);
```

`utf8::encode_one()` (and presumably other functions) rely on return 
type deduction. Sometimes they return a `_Result` directly, but sometimes
they return the result of invoking `__error_handler`. If they do both, then
`__error_handler` *must* return `_Result` or there will be conflicting return
type deduction. Explicitly annotating a return type that matches the
expectations of other error handlers, despite not returning normally, will
fix this compile-time error.