### PR TITLE
Add OSX GCC test, fix breakages on GCC 11.2

### DIFF
--- a/.github/workflows/macosx-gcc.yml
+++ b/.github/workflows/macosx-gcc.yml
@@ -1,0 +1,35 @@
+name: Mac OSX GCC
+
+on: [push, pull_request]
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: configure
+      run: |
+        cmake -B build/debug   -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -D ZTD_TEXT_TESTS=ON -D ZTD_TEXT_EXAMPLES=ON -D ZTD_TEXT_GENERATE_SINGLE=ON
+        cmake -B build/release -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -D ZTD_TEXT_TESTS=ON -D ZTD_TEXT_EXAMPLES=ON -D ZTD_TEXT_GENERATE_SINGLE=ON
+
+    - name: build
+      run: |
+        cmake --build build/debug   --config Debug
+        cmake --build build/release --config Release
+
+    - name: test
+      run: |
+        cd build/debug
+        ctest --build-config Debug
+        cd ../..
+        cd build/release
+        ctest --build-config Release
+        cd ../..

--- a/examples/documentation/snippets/source/runtime_locale_encoding.cpp
+++ b/examples/documentation/snippets/source/runtime_locale_encoding.cpp
@@ -30,7 +30,7 @@
 
 #include <ztd/text.hpp>
 
-#if !defined(_LIBCPP_VERSION)
+#if !defined(_LIBCPP_VERSION) && ZTD_IS_OFF(ZTD_PLATFORM_MAC_OS_I_)
 // This example doesn't work on Apple/libc++ because they don't have
 // standard C or C++ headers.
 

--- a/include/ztd/text/execution.hpp
+++ b/include/ztd/text/execution.hpp
@@ -62,7 +62,7 @@ namespace ztd { namespace text {
 	/// do not support the @c \<cuchar\> or @c \<uchar.h\> headers.
 	//////
 	using execution_t =
-#if ZTD_IS_ON(ZTD_CUCHAR_I_) || ZTD_IS_ON(ZTD_UCHAR_I_)
+#if (ZTD_IS_ON(ZTD_CUCHAR_I_) || ZTD_IS_ON(ZTD_UCHAR_I_)) && ZTD_IS_OFF(ZTD_PLATFORM_MAC_OS_I_)
 		__txt_impl::__execution_cuchar
 #elif ZTD_IS_ON(ZTD_PLATFORM_MAC_OS_I_)
 		__txt_impl::__execution_mac_os

--- a/include/ztd/text/forward.hpp
+++ b/include/ztd/text/forward.hpp
@@ -111,7 +111,7 @@ namespace ztd { namespace text {
 	using utf32_t = basic_utf32<char32_t, unicode_code_point>;
 
 	using execution_t =
-#if ZTD_IS_ON(ZTD_CUCHAR_I_) || ZTD_IS_ON(ZTD_UCHAR_I_)
+#if (ZTD_IS_ON(ZTD_CUCHAR_I_) || ZTD_IS_ON(ZTD_UCHAR_I_)) && ZTD_IS_OFF(ZTD_PLATFORM_MAC_OS_I_)
 		__txt_impl::__execution_cuchar
 #elif ZTD_IS_ON(ZTD_TEXT_ICONV_I_)
 		__txt_impl::__execution_iconv

--- a/include/ztd/text/impl/execution_cuchar.hpp
+++ b/include/ztd/text/impl/execution_cuchar.hpp
@@ -53,7 +53,7 @@
 #include <ztd/idk/encoding_detection.h>
 #include <ztd/idk/detail/windows.hpp>
 
-#if ZTD_IS_ON(ZTD_CUCHAR_I_) || ZTD_IS_ON(ZTD_UCHAR_I_)
+#if (ZTD_IS_ON(ZTD_CUCHAR_I_) || ZTD_IS_ON(ZTD_UCHAR_I_)) && ZTD_IS_OFF(ZTD_PLATFORM_MAC_OS_I_)
 
 // clang-format off
 #if ZTD_IS_ON(ZTD_CUCHAR_I_)

--- a/include/ztd/text/impl/wide_execution_cwchar.hpp
+++ b/include/ztd/text/impl/wide_execution_cwchar.hpp
@@ -454,7 +454,9 @@ namespace ztd { namespace text {
 				}
 
 				execution_t __exec {};
-				__txt_detail::__pass_through_handler_with<!__call_error_handler> __intermediate_handler {};
+				__txt_detail::__progress_handler<::std::integral_constant<bool, !__call_error_handler>,
+					__wide_execution_cwchar>
+					__intermediate_handler {};
 				::ztd::span<char, __state_max> __intermediate_input(__intermediate_buffer, __state_max);
 				auto __result = __exec.decode_one(__intermediate_input, ::std::forward<_OutputRange>(__output),
 					__intermediate_handler, __s.__narrow_state);
@@ -466,7 +468,7 @@ namespace ztd { namespace text {
 							             ::std::move(__inlast)),
 							     ::std::move(__result.output), __s, __result.error_code),
 							::ztd::span<code_unit>(::std::addressof(__units[0]), __units_count),
-							__intermediate_handler.__M_code_points_progress());
+							__intermediate_handler._M_code_points_progress());
 					}
 				}
 				return _Result(ranges::reconstruct(


### PR DESCRIPTION
Demonstrates failure to build on OSX under GCC due to failure to use `execution_mac_os.hpp`