### PR TITLE
add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# renormalize line endings (gh-34, gh-35)
+b91f5c3e21ccb87d5f8eff6e73a25debc403cd41
+a63e1ccb666503689f21975ba529711e3ab1916e


### PR DESCRIPTION
Add commits from #34 & #35 to `.git-blame-ignore-revs` so they don't show up in the blame; see [docs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)